### PR TITLE
Diagnostic Log

### DIFF
--- a/LWM2M_Diagnostics-v1_0.xml
+++ b/LWM2M_Diagnostics-v1_0.xml
@@ -54,6 +54,24 @@
                 <Units></Units>
                 <Description><![CDATA[Overriding visible lux value.]]></Description>
             </Item>
+            <Item ID="2000"><Name>Diagnostic Log</Name>
+                <Operations>R</Operations>
+                <MultipleInstances>Single</MultipleInstances>
+                <Mandatory>Mandatory</Mandatory>
+                <Type>String</Type>
+                <RangeEnumeration></RangeEnumeration>
+                <Units></Units>
+                <Description><![CDATA[Diagnostic log.]]></Description>
+            </Item>
+            <Item ID="2001"><Name>Diagnostic Log Mask</Name>
+                <Operations>RW</Operations>
+                <MultipleInstances>Single</MultipleInstances>
+                <Mandatory>Optional</Mandatory>
+                <Type>Integer</Type>
+                <RangeEnumeration></RangeEnumeration>
+                <Units></Units>
+                <Description><![CDATA[Diagnostic log mask value.]]></Description>
+            </Item>
             </Resources>
 		<Description2></Description2>		
 	</Object>


### PR DESCRIPTION
## Description
Added support for the following:
* /35000/0/2000 - diagnostic log, string that captures diagnostic messages from the cube
* /35000/0/2001 - diagnostic log bitmask, default to 0x0001, and can be set to enable logging of more modules

Current bitmask definitions for the log mask include:
* 0x01 - core logging (connectivity, factory reset)
* 0x02 - radar (people count change, approach logic and events)

