### PR TITLE
Manufacturing Settings

### DIFF
--- a/LWM2M_Mfg_Settings-v1_0.xml
+++ b/LWM2M_Mfg_Settings-v1_0.xml
@@ -1,0 +1,33 @@
+<LWM2M xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://openmobilealliance.org/tech/profiles/LWM2M.xsd">
+    <Object ObjectType="MODefinition">
+        <Name>Mfg Settings</Name>
+        <Description1><![CDATA[This LWM2M Object provides settings that can be configured during manufacturing.]]></Description1>
+        <ObjectID>35004</ObjectID>
+        <ObjectURN>urn:oma:lwm2m:x:35004</ObjectURN>
+        <LWM2MVersion>1.0</LWM2MVersion>
+        <ObjectVersion>1.0</ObjectVersion>
+        <MultipleInstances>Multiple</MultipleInstances>
+        <Mandatory>Optional</Mandatory>
+        <Resources>
+            <Item ID="0"><Name>Enabled</Name>
+                <Operations>R</Operations>
+                <MultipleInstances>Single</MultipleInstances>
+                <Mandatory>Mandatory</Mandatory>
+                <Type>Integer</Type>
+                <RangeEnumeration></RangeEnumeration>
+                <Units></Units>
+                <Description><![CDATA[MFG settings enabled.]]></Description>
+            </Item>
+            <Item ID="1"><Name>Model ID</Name>
+                <Operations>RW</Operations>
+                <MultipleInstances>Single</MultipleInstances>
+                <Mandatory>Optional</Mandatory>
+                <Type>String</Type>
+                <RangeEnumeration></RangeEnumeration>
+                <Units></Units>
+                <Description><![CDATA[Model ID.]]></Description>
+            </Item>
+            </Resources>
+        <Description2></Description2>
+    </Object>
+</LWM2M>

--- a/LWM2M_Mfg_Settings-v1_0.xml
+++ b/LWM2M_Mfg_Settings-v1_0.xml
@@ -18,14 +18,14 @@
                 <Units></Units>
                 <Description><![CDATA[MFG settings enabled.]]></Description>
             </Item>
-            <Item ID="1"><Name>Model ID</Name>
+            <Item ID="1"><Name>Model Number</Name>
                 <Operations>RW</Operations>
                 <MultipleInstances>Single</MultipleInstances>
                 <Mandatory>Optional</Mandatory>
                 <Type>String</Type>
                 <RangeEnumeration></RangeEnumeration>
                 <Units></Units>
-                <Description><![CDATA[Model ID.]]></Description>
+                <Description><![CDATA[Model number.]]></Description>
             </Item>
             </Resources>
         <Description2></Description2>


### PR DESCRIPTION
## Description
Added a mfg-settings object to configure settings during manufacturing.  Currently supports adjusting the model number for Air (WA240) and Air+ (WA280).