### PR TITLE
Radar Approach and Thread Reset

### DIFF
--- a/LWM2M_Combined_Radar-v1_0.xml
+++ b/LWM2M_Combined_Radar-v1_0.xml
@@ -48,6 +48,16 @@
                 <Units>sec</Units>
                 <Description>The shortest rate (in seconds) at which radar samples should be sent to the backend if there is no occupancy.</Description>
             </Item>
+            <Item ID="5">
+                <Name>Approach Distance</Name>
+                <Operations>RW</Operations>
+                <MultipleInstances>Single</MultipleInstances>
+                <Mandatory>Optional</Mandatory>
+                <Type>Float</Type>
+                <RangeEnumeration>0-4</RangeEnumeration>
+                <Units>meters</Units>
+                <Description>The largest distance (in meters) at which an object is considered to be approaching.</Description>
+            </Item>
         </Resources>
         <Description2></Description2>       
     </Object>

--- a/LWM2M_Thread_Commands-v1_0.xml
+++ b/LWM2M_Thread_Commands-v1_0.xml
@@ -1,0 +1,24 @@
+<LWM2M xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://openmobilealliance.org/tech/profiles/LWM2M.xsd">
+    <Object ObjectType="MODefinition">
+        <Name>Thread Commands</Name>
+        <Description1><![CDATA[This LWM2M Object provides support for thread commands.]]></Description1>
+        <ObjectID>35005</ObjectID>
+        <ObjectURN>urn:oma:lwm2m:x:35005</ObjectURN>
+        <LWM2MVersion>1.0</LWM2MVersion>
+        <ObjectVersion>1.0</ObjectVersion>
+        <MultipleInstances>Single</MultipleInstances>
+        <Mandatory>Optional</Mandatory>
+        <Resources>
+            <Item ID="0"><Name>Thread Reset</Name>
+                <Operations>E</Operations>
+                <MultipleInstances>Single</MultipleInstances>
+                <Mandatory>Optional</Mandatory>
+                <Type></Type>
+                <RangeEnumeration></RangeEnumeration>
+                <Units></Units>
+                <Description><![CDATA[Reset the thread radio.]]></Description>
+            </Item>
+            </Resources>
+        <Description2></Description2>
+    </Object>
+</LWM2M>


### PR DESCRIPTION
## Description
Added the following:
* /35002/0/5 - Set / read the radar "approach" distance threshold, or the distance in meters at which the radar indicates a person is "approaching".  This event will turn on the LEDs.  Configurable from 0 to 4.0 meters.
* /35005/0/0 - Executable command to reset the Thread radio (and MCU)